### PR TITLE
Update Z80.tmLanguage

### DIFF
--- a/syntaxes/Z80.tmLanguage
+++ b/syntaxes/Z80.tmLanguage
@@ -7,6 +7,7 @@
 	<key>fileTypes</key>
 	<array>
 		<string>asm</string>
+		<string>z80</string>
 		<string>z80s</string>
 		<string>s</string>
 	</array>


### PR DESCRIPTION
Fix for issue #5 - was missing .z80 filetype, but it's specified in the extension manifest as supported.